### PR TITLE
Remove cached property and chain tests

### DIFF
--- a/napari/utils/transforms/_tests/test_transform_chain.py
+++ b/napari/utils/transforms/_tests/test_transform_chain.py
@@ -112,3 +112,12 @@ def test_delitem_invalidates_cache():
 
     npt.assert_array_equal(chain((1, 1)), (2, 3))
     npt.assert_array_equal(chain.inverse((1, 1)), (1 / 2, 1 / 3))
+
+
+def test_mutate_item_invalidates_cache():
+    chain = TransformChain((Affine(scale=(2, 3)), Affine(scale=(4, 5))))
+
+    chain[0].scale = (1, -1)
+
+    npt.assert_array_equal(chain((1, 1)), (4, -5))
+    npt.assert_array_equal(chain.inverse((1, 1)), (1 / 4, -1 / 5))

--- a/napari/utils/transforms/_tests/test_transform_chain.py
+++ b/napari/utils/transforms/_tests/test_transform_chain.py
@@ -81,10 +81,10 @@ def test_transform_chain_expanded(Transform):
 
     transform_chain_a = TransformChain([transform_a, transform_b])
     transform_chain_b = TransformChain([transform_c, transform_d])
-    transform_chain_expandded = transform_chain_b.expand_dims([1])
+    transform_chain_expanded = transform_chain_b.expand_dims([1])
 
     new_coord_2 = transform_chain_a(coord)
-    new_coord_1 = transform_chain_expandded(coord)
+    new_coord_1 = transform_chain_expanded(coord)
     npt.assert_allclose(new_coord_1, new_coord_2)
 
 
@@ -94,3 +94,21 @@ def test_base_transform_init_is_called():
     # no attribute 'name'.
     chain = TransformChain()
     assert chain.name is None
+
+
+def test_setitem_invalidates_cache():
+    chain = TransformChain((Affine(scale=(2, 3)), Affine(scale=(4, 5))))
+
+    chain[0] = Affine(scale=(1, -1))
+
+    npt.assert_array_equal(chain((1, 1)), (4, -5))
+    npt.assert_array_equal(chain.inverse((1, 1)), (1 / 4, -1 / 5))
+
+
+def test_delitem_invalidates_cache():
+    chain = TransformChain((Affine(scale=(2, 3)), Affine(scale=(4, 5))))
+
+    del chain[1]
+
+    npt.assert_array_equal(chain((1, 1)), (2, 3))
+    npt.assert_array_equal(chain.inverse((1, 1)), (1 / 2, 1 / 3))

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Generic, Iterable, Optional, Sequence, TypeVar, overload
 
 import numpy as np
@@ -107,7 +106,7 @@ class Transform:
     def _is_diagonal(self):
         """Indicate when a transform does not mix or permute dimensions.
 
-        Can be overriden in subclasses to enable performance optimizations
+        Can be overridden in subclasses to enable performance optimizations
         that are specific to this case.
         """
         return False
@@ -705,7 +704,7 @@ class Affine(Transform):
             name=self.name,
         )
 
-    @cached_property
+    @property
     def _is_diagonal(self):
         """Determine whether linear_matrix is diagonal up to some tolerance.
 


### PR DESCRIPTION
This fixes the existing tests in https://github.com/napari/napari/pull/6536 by making `_is_diagonal` a `property` rather than a `cached_property`.

It also adds some tests to cover the cache invalidation logic for transform chains.

And fixes a few typos.