### PR TITLE
Use a context key and enablement for File close

### DIFF
--- a/src/napari/_qt/_qapp_model/qactions/_file.py
+++ b/src/napari/_qt/_qapp_model/qactions/_file.py
@@ -9,7 +9,7 @@ from app_model.types import (
     KeyMod,
     StandardKeyBinding,
 )
-from PyQt6.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 from napari._app_model.constants import MenuGroup, MenuId
 from napari._app_model.context import (
@@ -44,12 +44,9 @@ def _restart(window: Window):
 
 def _close_window(window: Window):
     active_window = QApplication.activeWindow()
-    if active_window is None:
+    if active_window is None or active_window is not window._qt_window:
         return
-    if active_window is not window._qt_window:
-        active_window.close()
-    else:
-        window._qt_window.close(quit_app=False, confirm_need=True)
+    window._qt_window.close(quit_app=False, confirm_need=True)
 
 
 def _close_app(window: Window):
@@ -180,6 +177,7 @@ Q_FILE_ACTIONS: list[Action] = [
         callback=_close_window,
         menus=[{'id': MenuId.MENUBAR_FILE, 'group': MenuGroup.CLOSE}],
         keybindings=[StandardKeyBinding.Close],
+        enablement='_is_active_window',
     ),
     Action(
         id='napari.window.file.restart',

--- a/src/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/src/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -220,13 +220,15 @@ def test_preferences_dialog_ok(qtbot, pref):
 def test_preferences_dialog_close(qtbot, pref):
     with qtbot.waitSignal(pref.finished):
         pref.close()
-    assert get_settings().appearance.theme == 'light'
+    # close acts as cancel, so theme should be unchanged
+    assert get_settings().appearance.theme == 'dark'
 
 
 def test_preferences_dialog_escape(qtbot, pref):
     with qtbot.waitSignal(pref.finished):
         qtbot.keyPress(pref, Qt.Key_Escape)
-    assert get_settings().appearance.theme == 'light'
+    # escape acts as cancel, so theme should be unchanged
+    assert get_settings().appearance.theme == 'dark'
 
 
 @pytest.mark.key_bindings
@@ -362,3 +364,11 @@ def test_startup_script_file_extension(pref):
         pref._stack.widget(0).widget().widget.widgets['startup_script']
     )
     assert startup_script_widget.file_filter() == 'File (*.py)'
+
+
+@pytest.mark.parametrize('modifier', [Qt.ControlModifier, Qt.MetaModifier])
+def test_preferences_dialog_ctrl_w(qtbot, pref, modifier):
+    with qtbot.waitSignal(pref.finished):
+        qtbot.keyPress(pref, Qt.Key_W, modifier)
+    # Control/Command-W acts as cancel, so theme should be unchanged
+    assert get_settings().appearance.theme == 'dark'

--- a/src/napari/_qt/dialogs/preferences_dialog.py
+++ b/src/napari/_qt/dialogs/preferences_dialog.py
@@ -265,7 +265,7 @@ class PreferencesDialog(QDialog):
 
     def closeEvent(self, event: 'QCloseEvent') -> None:
         event.accept()
-        self.accept()
+        self.reject()
 
     def accept(self):
         self._settings.save()

--- a/src/napari/_qt/dialogs/preferences_dialog.py
+++ b/src/napari/_qt/dialogs/preferences_dialog.py
@@ -75,11 +75,21 @@ class PreferencesDialog(QDialog):
         self._rebuild_dialog()
 
     def keyPressEvent(self, e: 'QKeyEvent'):
+        # escape and close keybind should just close the window
+        # which implies "reject" like clicking cancel
         if e.key() == Qt.Key.Key_Escape:
-            # escape key should just close the window
-            # which implies "accept"
             e.accept()
-            self.accept()
+            self.reject()
+            return
+        if e.key() == Qt.Key.Key_W and (
+            e.modifiers()
+            & (
+                Qt.KeyboardModifier.ControlModifier
+                | Qt.KeyboardModifier.MetaModifier
+            )
+        ):
+            e.accept()
+            self.reject()
             return
         super().keyPressEvent(e)
 


### PR DESCRIPTION
I think the issue is that the File menu item/action remains available and triggers the viewer to close.
That's what I worked on here.
Add a viewer_context key, add those keys to the File menu, use that as enablement for close in File menu.

Then in the dialog just bind Command/Control-W to reject.

