### PR TITLE
Reject changes on escape and closeEvent

### DIFF
--- a/src/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/src/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -220,13 +220,13 @@ def test_preferences_dialog_ok(qtbot, pref):
 def test_preferences_dialog_close(qtbot, pref):
     with qtbot.waitSignal(pref.finished):
         pref.close()
-    assert get_settings().appearance.theme == 'light'
+    assert get_settings().appearance.theme == 'dark'
 
 
 def test_preferences_dialog_escape(qtbot, pref):
     with qtbot.waitSignal(pref.finished):
         qtbot.keyPress(pref, Qt.Key_Escape)
-    assert get_settings().appearance.theme == 'light'
+    assert get_settings().appearance.theme == 'dark'
 
 
 @pytest.mark.key_bindings

--- a/src/napari/_qt/dialogs/preferences_dialog.py
+++ b/src/napari/_qt/dialogs/preferences_dialog.py
@@ -79,7 +79,7 @@ class PreferencesDialog(QDialog):
             # escape key should just close the window
             # which implies "accept"
             e.accept()
-            self.accept()
+            self.reject()
             return
         super().keyPressEvent(e)
 
@@ -255,7 +255,7 @@ class PreferencesDialog(QDialog):
 
     def closeEvent(self, event: 'QCloseEvent') -> None:
         event.accept()
-        self.accept()
+        self.reject()
 
     def accept(self):
         self._settings.save()


### PR DESCRIPTION
Suggestion to https://github.com/napari/napari/pull/8548 to ensure the behavior is as expected regarding settings being (not) saved (see the issue)
Alternative to #43 
Make escape and closeEvent reject changes.
So with your code making Close close the right window this makes the behavior correct.

